### PR TITLE
Align changed files count

### DIFF
--- a/lib/views/changed-files-count-view.js
+++ b/lib/views/changed-files-count-view.js
@@ -23,8 +23,9 @@ export default class ChangedFilesCountView extends React.Component {
     return (
       <a
         ref="changedFiles"
-        className="github-ChangedFilesCount inline-block icon icon-diff"
+        className="github-ChangedFilesCount inline-block"
         onClick={this.props.didClick}>
+        <Octicon icon="diff" />
         {label}
         {this.props.mergeConflictsPresent && <Octicon icon="alert" />}
       </a>

--- a/styles/changed-files-count-view.less
+++ b/styles/changed-files-count-view.less
@@ -4,15 +4,8 @@
 
 .github-ChangedFilesCount {
 
-  &.icon.icon-diff {
-    display: inline-block;
-    vertical-align: top;
-    line-height: 2.5;
-
-    &::before {
-      margin-right: .2em;
-      vertical-align: text-bottom; // Visually adjusted
-    }
+  &.icon-diff::before {
+    margin-right: .2em;
   }
 
 }

--- a/styles/push-pull-view.less
+++ b/styles/push-pull-view.less
@@ -7,12 +7,6 @@
   &-icon.icon.icon.icon {
     margin-right: 0;
     text-align: center;
-    vertical-align: top;
-    line-height: 2.5;
-
-    &::before {
-      vertical-align: text-bottom; // Visually adjusted
-    }
   }
 
   &-label.is-pull {

--- a/styles/status-bar-tile-controller.less
+++ b/styles/status-bar-tile-controller.less
@@ -46,17 +46,6 @@
     margin-left: @component-padding / 2;
   }
 
-  .github-branch {
-    .icon.icon-git-branch {
-      line-height: 2.5;
-      vertical-align: top;
-
-      &::before {
-        vertical-align: text-bottom; // Visually adjusted
-      }
-    }
-  }
-
   .github-branch-detached {
     color: @text-color-subtle;
     font-style: italic;


### PR DESCRIPTION
This PR is on top of https://github.com/atom/github/pull/1182. It:

1. Reverts the styling changes
2. Moves the icon into a child `<span>` element

It should remove the 1px gap at the top and keep the baseline unchanged.

![image](https://user-images.githubusercontent.com/378023/33860832-05be32f0-df1e-11e7-89fb-ff6d77221399.png)